### PR TITLE
JSON Cookie store support, Added cookie object extraction, Much higher cookie limits without hard coded numbers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/coucal"]
 	path = src/coucal
 	url = https://github.com/xroche/coucal.git
+[submodule "src/cJSON"]
+	path = src/cJSON
+	url = https://github.com/DaveGamble/cJSON.git

--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -241,7 +241,7 @@ Build options:
   X *purge old files after update (X0 keep delete) (--purge-old[=N])
 
 Spider options:
-  bN accept cookies in cookies.txt (0=do not accept,* 1=accept) (--cookies[=N])
+  bN accept cookies in cookies.txt (0=do not accept,* 1=accept use netscape cookies.txt 2=accept use cookies.json) (--cookies[=N])
   u  check document type if unknown (cgi,asp..) (u0 don't check, * u1 check but /, u2 check always) (--check-type[=N])
   j *parse Java Classes (j0 don't parse) (--parse-java[=N])
   sN follow robots.txt and meta robots tags (0=never,1=sometimes,* 2=always) (--robots[=N])

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -309,7 +309,7 @@ links conversion to UTF\-8 (\-\-utf8\-conversion)
 
 .SS Spider options:
 .IP \-bN
-accept cookies in cookies.txt (0=do not accept,* 1=accept) (\-\-cookies[=N])
+accept cookies in cookies.txt (0=do not accept,* 1=accept use netscape cookies.txt 2=accept use cookies.json) (\-\-cookies[=N])
 .IP \-u
 check document type if unknown (cgi,asp..) (u0 don t check, * u1 check but /, u2 check always) (\-\-check\-type[=N])
 .IP \-j

--- a/src/htsbauth.c
+++ b/src/htsbauth.c
@@ -39,40 +39,55 @@ Please visit our Website: http://www.httrack.com
 #include "htsglobal.h"
 #include "htslib.h"
 #include "htscore.h"
+#include "cJSON\cJSON.h"
+#define JS_ERR_BUF_SIZE 1024
+#define JS_MAX_BUF_SIZE 1024*1024
+#define JS_CJSON_ERROR -123928
+#define JS_UNEXPECTED_DATA_TYPE_ERRNO ENOMSG
+
+
+void DEBUG_COOK_PRINT_EXPANDED(const char* context, t_cookie_expanded* cookie_expanded);
+errno_t cjson_SafeReadString(const cJSON* object, const char* string_property, char* buffer, size_t buffer_size);
+errno_t cjson_SafeWriteString(const cJSON* object, const char* string_property, const char* string_val);
+int save_json_cookies_to_file(FILE* fp, t_cookie* cookie);
+errno_t _save_cookie_json(FILE* fp, t_cookie* cookie);
+int parse_json_cookies_from_file(FILE* fp, t_cookie* cookie);
+errno_t _parse_cookie_json(FILE* fp, t_cookie* out_cookie);
 
 /* END specific definitions */
 
 // gestion des cookie
 // ajoute, dans l'ordre
 // !=0 : erreur
-int cookie_add(t_cookie * cookie, const char *cook_name, const char *cook_value,
-               const char *domain, const char *path) {
-  char buffer[8192];
+int cookie_add(t_cookie* cookie, const char* cook_name, const char* cook_value,
+	const char* domain, const char* path) {
+	t_cookie_expanded expanded;
+	if (strlen(cook_value) > sizeof(expanded.cook_value))
+		return -1;                  // trop long
+	if (strlen(cook_name) > sizeof(expanded.cook_name))
+		return -1;                  // trop long
+	if (strlen(domain) > sizeof(expanded.domain))
+		return -1;                  // trop long
+	if (strlen(path) > sizeof(expanded.path))
+		return -1;                  // trop long
+	strcpy_s(expanded.cook_value, sizeof(expanded.cook_value), cook_value);
+	strcpy_s(expanded.cook_name, sizeof(expanded.cook_name), cook_name);
+	strcpy_s(expanded.domain, sizeof(expanded.domain), domain);
+	strcpy_s(expanded.path, sizeof(expanded.path), path);
+	return cookie_addE(cookie, &expanded);
+}
+int cookie_addE(t_cookie * cookie, t_cookie_expanded * cookie_expanded) {
+  char buffer[COOKIE_SINGLE_MAX_SIZE];
   char *a = cookie->data;
   char *insert;
-  char cook[16384];
+  char cook[COOKIE_VALUE_BUFFER_SIZE*2];
+  
 
   // effacer éventuel cookie en double
-  cookie_del(cookie, cook_name, domain, path);
-  if (strlen(cook_value) > 1024)
-    return -1;                  // trop long
-  if (strlen(cook_name) > 256)
-    return -1;                  // trop long
-  if (strlen(domain) > 256)
-    return -1;                  // trop long
-  if (strlen(path) > 256)
-    return -1;                  // trop long
-  if (strlen(cookie->data)
-             + strlen(cook_value)
-             + strlen(cook_name)
-             + strlen(domain)
-             + strlen(path)
-             + 256 > cookie->max_len)
-    return -1;                  // impossible d'ajouter
-
+  cookie_del(cookie, cookie_expanded->cook_name, cookie_expanded->domain, cookie_expanded->path);
   insert = a;                   // insérer ici
   while(*a) {
-    if (strlen(cookie_get(buffer, a, 2)) < strlen(path))        // long. path (le + long est prioritaire)
+    if (strlen(cookie_get(buffer, a, COOK_PARAM_PATH)) < strlen(cookie_expanded->path))        // long. path (le + long est prioritaire)
       a = cookie->data + strlen(cookie->data);  // fin
     else {
       a = strchr(a, '\n');      // prochain champ
@@ -86,26 +101,25 @@ int cookie_add(t_cookie * cookie, const char *cook_name, const char *cook_value,
     }
   }
   // construction du cookie
-  strcpybuff(cook, domain);
+  strcpybuff(cook, cookie_expanded->domain);
   strcatbuff(cook, "\t");
   strcatbuff(cook, "TRUE");
   strcatbuff(cook, "\t");
-  strcatbuff(cook, path);
+  strcatbuff(cook, cookie_expanded->path);
   strcatbuff(cook, "\t");
   strcatbuff(cook, "FALSE");
   strcatbuff(cook, "\t");
   strcatbuff(cook, "1999999999");
   strcatbuff(cook, "\t");
-  strcatbuff(cook, cook_name);
+  strcatbuff(cook, cookie_expanded->cook_name);
   strcatbuff(cook, "\t");
-  strcatbuff(cook, cook_value);
+  strcatbuff(cook, cookie_expanded->cook_value);
   strcatbuff(cook, "\n");
   if (!((strlen(cookie->data) + strlen(cook)) < cookie->max_len))
     return -1;                  // impossible d'ajouter
   cookie_insert(insert, cook);
 #if DEBUG_COOK
-  printf("add_new cookie: name=\"%s\" value=\"%s\" domain=\"%s\" path=\"%s\"\n",
-         cook_name, cook_value, domain, path);
+  DEBUG_COOK_PRINT_EXPANDED("add new cookie", cookie_expanded);
   //printf(">>>cook: %s<<<\n",cookie->data);
 #endif
   return 0;
@@ -152,9 +166,14 @@ static int cookie_cmp_wildcard_domain(const char *chk_dom, const char *domain) {
 // rechercher cookie à partir de la position s (par exemple s=cookie.data)
 // renvoie pointeur sur ligne, ou NULL si introuvable
 // path est aligné à droite et cook_name peut être vide (chercher alors tout cookie)
+/* english trans:
+	// search cookie from position s (for example s=cookie.data)
+	// returns pointer to row, or NULL if not found
+	// path is right-aligned and cook_name can be empty (then search for any cookie)
+*/
 // .doubleclick.net     TRUE    /       FALSE   1999999999      id      A
 char *cookie_find(char *s, const char *cook_name, const char *domain, const char *path) {
-  char buffer[8192];
+  char buffer[COOKIE_VALUE_BUFFER_SIZE];
   char *a = s;
 
   while(*a) {
@@ -163,16 +182,16 @@ char *cookie_find(char *s, const char *cook_name, const char *domain, const char
     if (strnotempty(cook_name) == 0)
       t = 1;                    // accepter par défaut
     else
-      t = (strcmp(cookie_get(buffer, a, 5), cook_name) == 0);   // tester si même nom
+      t = (strcmp(cookie_get(buffer, a, COOK_PARAM_NAME), cook_name) == 0);   // tester si même nom
     if (t) {                    // même nom ou nom qualconque
       //
-      const char *chk_dom = cookie_get(buffer, a, 0); // domaine concerné par le cookie
+      const char *chk_dom = cookie_get(buffer, a, COOK_PARAM_DOMAIN); // domaine concerné par le cookie
 
       if ((strlen(chk_dom) <= strlen(domain) &&
         strcmp(chk_dom, domain + strlen(domain) - strlen(chk_dom)) == 0) ||
         !cookie_cmp_wildcard_domain(chk_dom, domain)) {  // même domaine
           //
-        const char *chk_path = cookie_get(buffer, a, 2);    // chemin concerné par le cookie
+        const char *chk_path = cookie_get(buffer, a, COOK_PARAM_PATH);    // chemin concerné par le cookie
 
         if (strlen(chk_path) <= strlen(path)) {
           if (strncmp(path, chk_path, strlen(chk_path)) == 0) {       // même chemin
@@ -204,110 +223,256 @@ char *cookie_nextfield(char *a) {
 // lire également (Windows seulement) les *@*.txt (cookies IE copiés)
 // !=0 : erreur
 int cookie_load(t_cookie * cookie, const char *fpath, const char *name) {
-  char catbuff[CATBUFF_SIZE];
-  char buffer[8192];
+  char file_path_buffer[CATBUFF_SIZE];
+  t_cookie_expanded cookie_expanded;
 
   //  cookie->data[0]='\0';
+  BOOL json_mode = strendwith_(name, ".json");
 
   // Fusionner d'abord les éventuels cookies IE
 #ifdef _WIN32
   {
-    WIN32_FIND_DATAA find;
-    HANDLE h;
-    char pth[MAX_PATH + 32];
+	  if (!json_mode) {
+		  WIN32_FIND_DATAA find;
+		  HANDLE h;
+		  char pth[MAX_PATH + 32];
 
-    strcpybuff(pth, fpath);
-    strcatbuff(pth, "*@*.txt");
-    h = FindFirstFileA((char *) pth, &find);
-    if (h != INVALID_HANDLE_VALUE) {
-      do {
-        if (!(find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
-          if (!(find.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM)) {
-            FILE *fp = fopen(fconcat(catbuff, sizeof(catbuff), fpath, find.cFileName), "rb");
+		  strcpybuff(pth, fpath);
+		  strcatbuff(pth, "*@*.txt");
+		  h = FindFirstFileA((char*)pth, &find);
+		  if (h != INVALID_HANDLE_VALUE) {
+			  do {
+				  if (!(find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+					  if (!(find.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM)) {
+						  FILE* fp = fopen(fconcat(file_path_buffer, sizeof(file_path_buffer), fpath, find.cFileName), "rb");
 
-            if (fp) {
-              char cook_name[256];
-              char cook_value[1000];
-              char domainpathpath[512];
-              char dummy[512];
+						  if (fp) {
+							  char dummy[COOKIE_PARAM_BUFFER_SIZE];
+							  
+							  //
+							  lien_adrfil af;   // chemin (/)
+							  int cookie_merged = 0;
 
-              //
-              lien_adrfil af;   // chemin (/)
-              int cookie_merged = 0;
+							  //
+							  // Read all cookies
+							  while (!feof(fp)) {
+								  cookie_expanded = EmptyExpandedCookieStruct;
+								  dummy[0] = af.adr[0] = af.fil[0] = '\0';
 
-              //
-              // Read all cookies
-              while(!feof(fp)) {
-                cook_name[0] = cook_value[0] = domainpathpath[0]
-                = dummy[0] = af.adr[0] = af.fil[0] = '\0';
-                linput(fp, cook_name, 250);
-                if (!feof(fp)) {
-                  linput(fp, cook_value, 250);
-                  if (!feof(fp)) {
-                    int i;
+								  linput(fp, cookie_expanded.cook_name, sizeof(cookie_expanded.cook_name));
+								  if (!feof(fp)) {
+									  linput(fp, cookie_expanded.cook_value, sizeof(cookie_expanded.cook_value));
+									  if (!feof(fp)) {
+										  int i;
 
-                    linput(fp, domainpathpath, 500);
-                    /* Read 6 other useless values */
-                    for(i = 0; !feof(fp) && i < 6; i++) {
-                      linput(fp, dummy, 500);
-                    }
-                    if (strnotempty(cook_name)
-                        && strnotempty(cook_value)
-                        && strnotempty(domainpathpath)) {
-                      if (ident_url_absolute(domainpathpath, &af) >= 0) {
-                        cookie_add(cookie, cook_name, cook_value, af.adr, af.fil);
-                        cookie_merged = 1;
-                      }
-                    }
-                  }
-                }
-              }
-              fclose(fp);
-              if (cookie_merged)
-                remove(fconcat(catbuff, sizeof(catbuff), fpath, find.cFileName));
-            }                   // if fp
-          }
-      } while(FindNextFileA(h, &find));
-      FindClose(h);
-    }
+										  linput(fp, cookie_expanded.path, sizeof(cookie_expanded.path));//technically this is domain and path so could be truncating to only path length but its quite long
+										  /* Read 6 other useless values */
+										  for (i = 0; !feof(fp) && i < 6; i++) {
+											  linput(fp, dummy, 500);
+										  }
+										  if (strnotempty(cookie_expanded.cook_name)
+											  && strnotempty(cookie_expanded.cook_value)
+											  && strnotempty(cookie_expanded.path)) {
+											  if (ident_url_absolute(cookie_expanded.path, &af) >= 0) {
+												  strcpy_s(cookie_expanded.domain, sizeof(cookie_expanded.domain), af.adr);
+												  strcpy_s(cookie_expanded.path, sizeof(cookie_expanded.path), af.fil);
+												  cookie_addE(cookie, &cookie_expanded);
+												  cookie_merged = 1;
+											  }
+										  }
+									  }
+								  }
+							  }
+							  fclose(fp);
+							  if (cookie_merged)
+								  remove(fconcat(file_path_buffer, sizeof(file_path_buffer), fpath, find.cFileName));
+						  }                   // if fp
+					  }
+			  } while (FindNextFileA(h, &find));
+			  FindClose(h);
+		  }
+	  }
   }
 #endif
 
   // Ensuite, cookies.txt
   {
-    FILE *fp = fopen(fconcat(catbuff, sizeof(catbuff), fpath, name), "rb");
-
+    FILE *fp = fopen(fconcat(file_path_buffer, sizeof(file_path_buffer), fpath, name), "rb");
+	
     if (fp) {
-      char BIGSTK line[8192];
+		if (!json_mode) {
+			char BIGSTK line[COOKIE_SINGLE_MAX_SIZE];
 
-      while((!feof(fp)) && (((int) strlen(cookie->data)) < cookie->max_len)) {
-        rawlinput(fp, line, 8100);
-        if (strnotempty(line)) {
-          if (strlen(line) < 8000) {
-            if (line[0] != '#') {
-              char domain[256]; // domaine cookie (.netscape.com)
-              char path[256];   // chemin (/)
-              char cook_name[1024];     // nom cookie (MYCOOK)
-              char BIGSTK cook_value[8192];     // valeur (ID=toto,S=1234)
-
-              strcpybuff(domain, cookie_get(buffer, line, 0));  // host
-              strcpybuff(path, cookie_get(buffer, line, 2));    // path
-              strcpybuff(cook_name, cookie_get(buffer, line, 5));       // name
-              strcpybuff(cook_value, cookie_get(buffer, line, 6));      // value
-#if DEBUG_COOK
-              printf("%s\n", line);
-#endif
-              cookie_add(cookie, cook_name, cook_value, domain, path);
-            }
-          }
-        }
-      }
+			while ((!feof(fp)) && (((int)strlen(cookie->data)) < cookie->max_len)) {
+				rawlinput(fp, line, sizeof(line));
+				if (strnotempty(line)) {
+					if (strlen(line) < COOKIE_SINGLE_MAX_SIZE) {
+						if (line[0] != '#') {
+							cookie_expanded = cookie_getE(line);
+							DEBUG_COOK_PRINT_EXPANDED("File read cookie", &cookie_expanded);
+							cookie_addE(cookie, &cookie_expanded);
+						}
+					}
+				}
+			}
+		}
+		else
+			parse_json_cookies_from_file(fp, cookie);
+		
       fclose(fp);
       return 0;
     }
   }
   return -1;
 }
+
+void DEBUG_COOK_PRINT_EXPANDED(const char * context, t_cookie_expanded * cookie_expanded) {
+#ifdef  DEBUG_COOK
+	printf_s("%s: name: %s val: %s dom: %s path: %s\n", context, cookie_expanded->cook_name, cookie_expanded->cook_value, cookie_expanded->domain, cookie_expanded->path);
+#endif //  DEBUG_COOK
+}
+errno_t cjson_SafeReadString(const cJSON* object, const char* string_property, char* buffer, size_t buffer_size) {
+	const cJSON* tmp = cJSON_GetObjectItem(object, string_property);
+	if (tmp == NULL)
+		return JS_CJSON_ERROR;
+	if (!cJSON_IsString(tmp))
+		return JS_UNEXPECTED_DATA_TYPE_ERRNO;
+	strcpy_s(buffer, buffer_size, tmp->valuestring);
+	return 0;
+}
+errno_t cjson_SafeWriteString(const cJSON* object, const char* string_property, const char* string_val) {
+	
+	const cJSON* tmp = cJSON_CreateString(string_val);
+	if (tmp == NULL)
+		return ENOMEM;
+	if (!cJSON_AddItemToObject(object, string_property, tmp)) {
+		cJSON_Delete(tmp);
+		return ENOMEM;
+	}
+	return 0;
+}
+int save_json_cookies_to_file(FILE* fp, t_cookie* to_save) {
+
+	char* b = to_save->data;
+	errno_t err = 0;
+	cJSON* cookies = cJSON_CreateArray();
+	if (cookies == NULL)
+		goto fail;
+	cJSON* cookie = NULL;
+	t_cookie_expanded cookie_expanded;
+
+	while (b != NULL && b[0] != '\0') {
+		cookie_expanded = cookie_getE(b);
+		cookie = cJSON_CreateObject();
+		if (cookie == NULL)
+			goto fail;
+		if (!cJSON_AddItemToArray(cookies, cookie))
+			goto fail;
+		err = cjson_SafeWriteString(cookie, "name",cookie_expanded.cook_name);
+		if (err)
+			goto fail;
+		err = cjson_SafeWriteString(cookie, "value", cookie_expanded.cook_value);
+		if (err)
+			goto fail;
+		err = cjson_SafeWriteString(cookie, "domain", cookie_expanded.domain);
+		if (err)
+			goto fail;
+		err = cjson_SafeWriteString(cookie, "path", cookie_expanded.path);
+		if (err)
+			goto fail;
+		 
+		b = cookie_nextfield(b);
+	}
+	fputs( cJSON_Print(cookies), fp);
+	goto cleanup;
+
+fail:
+	if (cookies != NULL)//technically cookie as wel lcoudl not be added but additemtoarray shouldwnt fail
+		cJSON_Delete(cookies);
+	if (! err)
+		err = 1;
+cleanup:
+	fclose(fp);
+	return err;
+}
+int parse_json_cookies_from_file(FILE* fp, t_cookie* cookie) {
+	errno_t res = _parse_cookie_json(fp, cookie);
+	if (res != 0) {
+		if (res == JS_CJSON_ERROR) {
+			fprintf(stderr, "CJSON Parse Error at: %s", cJSON_GetErrorPtr());
+		}
+		else {
+			char errmsg[JS_ERR_BUF_SIZE];
+			strerror_s(errmsg, JS_ERR_BUF_SIZE, res);
+			fprintf(stderr, "Error parsing json: %s\n", errmsg);
+		}
+		return -1;
+	}
+
+	return 0;
+}
+errno_t _parse_cookie_json(FILE* fp, t_cookie* out_cookie) {
+	errno_t err;
+	cJSON* cookies = NULL;
+	char* buffer = NULL;
+	fseek(fp, 0L, SEEK_END);
+	const long numBytes = ftell(fp);
+	fseek(fp, 0L, SEEK_SET);
+	buffer = (char*)calloc(numBytes, sizeof(char));
+	if (buffer == NULL)
+		return ENOMEM;
+
+	fread_s(buffer, sizeof(char) * numBytes, sizeof(char), numBytes, fp);
+
+	t_cookie_expanded cookie_expanded;
+	cJSON* cookie = NULL;
+
+	cookies = cJSON_Parse(buffer);
+
+
+	if (cookies == NULL)
+		goto cjson_fail;
+	cJSON_ArrayForEach(cookie, cookies) {
+		if (cookie == NULL)
+			goto cjson_fail;
+		err = cjson_SafeReadString(cookie, "name", cookie_expanded.cook_name, COOKIE_PARAM_BUFFER_SIZE);
+		if (err)
+			goto fail;
+		err = cjson_SafeReadString(cookie, "value", cookie_expanded.cook_value, COOKIE_PARAM_BUFFER_SIZE);
+		if (err)
+			goto fail;
+		err = cjson_SafeReadString(cookie, "domain", cookie_expanded.domain, COOKIE_PARAM_BUFFER_SIZE);
+		if (err)
+			goto fail;
+		err = cjson_SafeReadString(cookie, "path", cookie_expanded.path, COOKIE_PARAM_BUFFER_SIZE);
+		if (err)
+			goto fail;
+		
+#if DEBUG_COOK
+		DEBUG_COOK_PRINT_EXPANDED("Read a json cookie", cookie_expanded);
+#endif
+		cookie_addE(out_cookie, &cookie_expanded);
+
+		
+	}
+	goto cleanup;
+
+cjson_fail:
+	err = JS_CJSON_ERROR;
+	goto cleanup;
+
+fail:
+	goto cleanup;
+cleanup:
+	cJSON_Delete(cookies);
+	if (buffer != NULL)
+		free(buffer);
+	if (fp != NULL)
+		fclose(fp);
+	return err;
+}
+
+
 
 // écrire cookies.txt
 // !=0 : erreur
@@ -315,26 +480,35 @@ int cookie_save(t_cookie * cookie, const char *name) {
   char catbuff[CATBUFF_SIZE];
 
   if (strnotempty(cookie->data)) {
-    char BIGSTK line[8192];
+    
     FILE *fp = fopen(fconv(catbuff, sizeof(catbuff), name), "wb");
+	BOOL json_mode = strendwith_(name, ".json");
 
-    if (fp) {
-      char *a = cookie->data;
+	if (fp) {
+		if (!json_mode ) {
+			char BIGSTK line[COOKIE_VALUE_BUFFER_SIZE];
 
-      fprintf(fp,
-              "# HTTrack Website Copier Cookie File" LF
-              "# This file format is compatible with Netscape cookies" LF);
-      do {
-        a += binput(a, line, 8000);
-        fprintf(fp, "%s" LF, line);
-      } while(strnotempty(line));
-      fclose(fp);
-      return 0;
-    }
+			char* a = cookie->data;
+
+			fprintf(fp,
+				"# HTTrack Website Copier Cookie File" LF
+				"# This file format is compatible with Netscape cookies" LF);
+			do {
+				a += binput(a, line, COOKIE_VALUE_BUFFER_SIZE);
+				fprintf(fp, "%s" LF, line);
+			} while (strnotempty(line));
+			fclose(fp);
+			return 0;
+		}
+		else {
+			save_json_cookies_to_file(fp, cookie);
+		}
+	}
   } else
     return 0;
   return -1;
 }
+
 
 // insertion chaine ins avant s
 void cookie_insert(char *s, const char *ins) {
@@ -369,9 +543,20 @@ void cookie_delete(char *s, size_t pos) {
   }
 }
 
+
+t_cookie_expanded cookie_getE(const char* cookie_base) {
+	t_cookie_expanded expanded;
+	char buffer[sizeof(expanded.cook_value)];//i doubt anything ever gets longer than value
+	strcpy_s(expanded.cook_value, sizeof(expanded.cook_value), cookie_get(buffer, cookie_base, COOK_PARAM_VALUE));
+	strcpy_s(expanded.cook_name, sizeof(expanded.cook_name), cookie_get(buffer, cookie_base, COOK_PARAM_NAME));
+	strcpy_s(expanded.domain, sizeof(expanded.domain), cookie_get(buffer, cookie_base, COOK_PARAM_DOMAIN));
+	strcpy_s(expanded.path, sizeof(expanded.path), cookie_get(buffer, cookie_base, COOK_PARAM_PATH));
+	return expanded;
+}
+
 // renvoie champ param de la chaine cookie_base
 // ex: cookie_get("ceci est<tab>un<tab>exemple",1) renvoi "un"
-const char *cookie_get(char *buffer, const char *cookie_base, int param) {
+const char *cookie_get(char *buffer, const char *cookie_base, COOK_PARAM_t param) {
   const char *limit;
 
   while(*cookie_base == '\n')

--- a/src/htscore.c
+++ b/src/htscore.c
@@ -147,7 +147,7 @@ RUN_CALLBACK0(opt, end); \
   if (opt->log != NULL) fflush(opt->log); \
   if (makestat_fp) { fclose(makestat_fp); makestat_fp=NULL; } \
   if (maketrack_fp){ fclose(maketrack_fp); maketrack_fp=NULL; } \
-  if (opt->accept_cookie) cookie_save(opt->cookie,fconcat(OPT_GET_BUFF(opt),OPT_GET_BUFF_SIZE(opt),StringBuff(opt->path_log),"cookies.txt")); \
+  if (opt->accept_cookie) cookie_save(opt->cookie,fconcat(OPT_GET_BUFF(opt),OPT_GET_BUFF_SIZE(opt),StringBuff(opt->path_log),opt->accept_cookie == 1 ? "cookies.txt" : "cookies.json")); \
   if (makeindex_fp) { fclose(makeindex_fp); makeindex_fp=NULL; } \
   if (cache_hashtable) { coucal_delete(&cache_hashtable); } \
   if (cache_tests)     { coucal_delete(&cache_tests); } \
@@ -521,11 +521,12 @@ int httpmirror(char *url1, httrackp * opt) {
   // initialiser cookie
   if (opt->accept_cookie) {
     opt->cookie = &cookie;
-    cookie.max_len = 30000;     // max len
+    cookie.max_len = sizeof(cookie.data);     // max len
     strcpybuff(cookie.data, "");
     // Charger cookies.txt par défaut ou cookies.txt du miroir
-    cookie_load(opt->cookie, StringBuff(opt->path_log), "cookies.txt");
-    cookie_load(opt->cookie, "", "cookies.txt");
+	char* cookieFName = opt->cookie == 1 ? "cookies.txt" : "cookies.json";
+    cookie_load(opt->cookie, StringBuff(opt->path_log), cookieFName);
+    cookie_load(opt->cookie, "", cookieFName);
   } else
     opt->cookie = NULL;
 

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1146,7 +1146,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
             httrack_logmode = 1;        // erreurs à l'écran
             opt->savename_type = 1003;  // mettre dans le répertoire courant
             opt->depth = 0;     // ne pas explorer la page
-            opt->accept_cookie = 0;     // pas de cookies
+            opt->accept_cookie = 0;     // 1 for cookies.txt 2 for cookies.json
             opt->robots = 0;    // pas de robots
             break;
           case 'w':

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1062,9 +1062,9 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
             cook = 1;
           } else
             print_buffer(&bstr, "; ");
-          print_buffer(&bstr, "%s", cookie_get(buffer, b, 5));
-          print_buffer(&bstr, "=%s", cookie_get(buffer, b, 6));
-          print_buffer(&bstr, "; $Path=%s", cookie_get(buffer, b, 2));
+          print_buffer(&bstr, "%s", cookie_get(buffer, b, COOK_PARAM_NAME));
+          print_buffer(&bstr, "=%s", cookie_get(buffer, b, COOK_PARAM_VALUE));
+          print_buffer(&bstr, "; $Path=%s", cookie_get(buffer, b, COOK_PARAM_PATH));
           b = cookie_nextfield(b);
         }
       } while(b != NULL && max_cookies > 0);

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -1051,7 +1051,7 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
       char buffer[8192];
       char *b = cookie->data;
       int cook = 0;
-      int max_cookies = 8;
+      int max_cookies = COOKIE_MAX;
 
       do {
         b = cookie_find(b, "", jump_identification_const(adr), fil);  // prochain cookie satisfaisant aux conditions
@@ -1067,7 +1067,7 @@ int http_sendhead(httrackp * opt, t_cookie * cookie, int mode,
           print_buffer(&bstr, "; $Path=%s", cookie_get(buffer, b, COOK_PARAM_PATH));
           b = cookie_nextfield(b);
         }
-      } while(b != NULL && max_cookies > 0);
+      } while(b != NULL && b[0] != '\0' && max_cookies > 0);
       if (cook) {               // on a envoyé un (ou plusieurs) cookie?
         print_buffer(&bstr, H_CRLF);
 #if DEBUG_COOK

--- a/src/httrack.vcxproj
+++ b/src/httrack.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-   <Import Project="..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.props" Condition="Exists('..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.props')" />
+  <Import Project="..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.props" Condition="Exists('..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.props')" />
   <Import Project="..\..\packages\openssl-native.1.0.0\build\native\openssl-native.props" Condition="Exists('..\..\packages\openssl-native.1.0.0\build\native\openssl-native.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -141,6 +141,7 @@
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_CONSOLE;HTS_ANALYSTE_CONSOLE;LIBHTTRACK_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <SupportJustMyCode>true</SupportJustMyCode>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -148,7 +149,9 @@
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <MapExports>true</MapExports>
+      <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -157,6 +160,8 @@
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_CONSOLE;HTS_ANALYSTE_CONSOLE;LIBHTTRACK_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -165,11 +170,12 @@
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AssemblyDebug>true</AssemblyDebug>
+      <StackReserveSize>16777216</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
-
-
-
   <ItemGroup>
     <ClCompile Include="httrack.c" />
   </ItemGroup>
@@ -184,7 +190,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
- <ImportGroup Label="ExtensionTargets">
+  <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\openssl-native.1.0.0\build\native\openssl-native.targets" Condition="Exists('..\..\packages\openssl-native.1.0.0\build\native\openssl-native.targets')" />
     <Import Project="..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.targets" Condition="Exists('..\..\packages\StoneSteps.zLib.Static.1.2.12.1\build\native\StoneSteps.zLib.Static.targets')" />
   </ImportGroup>

--- a/src/libhttrack.vcxproj
+++ b/src/libhttrack.vcxproj
@@ -142,6 +142,7 @@
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_USRDLL;LIBHTTRACK_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <SupportJustMyCode>true</SupportJustMyCode>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -149,6 +150,7 @@
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <MapExports>true</MapExports>
     </Link>
   </ItemDefinitionGroup>
@@ -158,6 +160,11 @@
       <PreprocessorDefinitions>_DEBUG;WIN32;_WINDOWS;_USRDLL;LIBHTTRACK_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <SupportJustMyCode>true</SupportJustMyCode>
+      <TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
+      <Optimization>Disabled</Optimization>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -165,10 +172,18 @@
     <Link>
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <MapExports>true</MapExports>
+      <AssemblyDebug>true</AssemblyDebug>
+      <StackReserveSize>
+      </StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="cJSON\cJSON.c" />
+    <ClCompile Include="path-join\path-join.c" />
+    <ClCompile Include="path-join\str-ends-with.c" />
+    <ClCompile Include="path-join\str-starts-with.c" />
     <ClCompile Include="coucal\coucal.c" />
     <ClCompile Include="htsalias.c" />
     <ClCompile Include="htsback.c" />
@@ -206,6 +221,10 @@
     <ClCompile Include="punycode.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="cJSON\cJSON.h" />
+    <ClInclude Include="path-join\path-join.h" />
+    <ClInclude Include="path-join\str-ends-with.h" />
+    <ClInclude Include="path-join\str-starts-with.h" />
     <ClInclude Include="coucal\coucal.h" />
     <ClInclude Include="hts-indextmpl.h" />
     <ClInclude Include="htsalias.h" />

--- a/src/libhttrack.vcxproj.filters
+++ b/src/libhttrack.vcxproj.filters
@@ -120,6 +120,18 @@
     <ClCompile Include="minizip\zip.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="path-join\path-join.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="path-join\str-ends-with.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="path-join\str-starts-with.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cJSON\cJSON.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="mmsrip\common.h">
@@ -254,11 +266,26 @@
     <ClInclude Include="minizip\zip.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="path-join\path-join.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="path-join\str-ends-with.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="path-join\str-starts-with.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="cJSON\cJSON.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Text Include="changelog.txt" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Library Include="$(ZLibDir)lib\$(Platform)\$(Configuration)\$(ZLibName).lib" />
   </ItemGroup>
 </Project>

--- a/src/webhttrack.vcxproj
+++ b/src/webhttrack.vcxproj
@@ -144,6 +144,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SupportJustMyCode>true</SupportJustMyCode>
+		<TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -163,6 +164,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SupportJustMyCode>true</SupportJustMyCode>
+		<TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -183,9 +185,6 @@
     <ClCompile Include="htsweb.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\path-join.h" />
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\str-ends-with.h" />
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\str-starts-with.h" />
     <ClInclude Include="htsserver.h" />
     <ClInclude Include="htsweb.h" />
   </ItemGroup>

--- a/src/webhttrack.vcxproj.filters
+++ b/src/webhttrack.vcxproj.filters
@@ -38,15 +38,6 @@
     <ClInclude Include="htsweb.h">
       <Filter>Resource Files</Filter>
     </ClInclude>
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\path-join.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\str-ends-with.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="C:\software\httrack-windows\httrack\src\path-join\str-starts-with.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />


### PR DESCRIPTION
minor debug improvements as well.  Use the new  --cookies 2 or -b2 option and see new type t_cookie_expanded  that cookie_getE can return or cookie_addE can take.  Also made the param parameter on cookie_get an enum.

Uses newly imported cJSON library,  cookie format matches the serialization of standard extension cookie object: https://wicg.github.io/cookie-store/#cookie

per cookie limits not match the RFC minimums but capped total cookies at 100 to avoid big stack changes (this up from 8 per domain).