### PR TITLE
HTTPS/SSL Proxy support!

### DIFF
--- a/html/fcguide.html
+++ b/html/fcguide.html
@@ -204,6 +204,7 @@ Action options:
 Proxy options:
   P  proxy use (-P proxy:port or -P user:pass@proxy:port) (--proxy <param>)
  %f *use proxy for ftp (f0 don't use) (--httpproxy-ftp[=N])
+ %C *use proxy for ssl (C0 don't use) (--httpproxy-ssl[=N])
 
 Limits options:
   rN set the mirror depth to N (* r9999) (--depth[=N])
@@ -407,6 +408,7 @@ site. Specifically, the defauls are:
 <pre>
   w *mirror web sites
  %f *use proxy for ftp (f0 don't use)
+ %C *use proxy for ssl (C0 don't use)
   cN number of multiple connections (*c8)
   RN number of retries, in case of timeout or non-fatal errors (*R1)
  %P *extended parsing, attempt to parse all links, even in unknown tags or Javascript (%P0 don't use)
@@ -441,6 +443,11 @@ for links to other URLs inside it, dowloading them as well.
 <p align=justify> If there are and links to ftp URLs (URLs using the
 file transfer protocol (FTP) rather than the hypertext transfer protocol
 HTTP), go through an ftp proxy server to get them.
+
+<pre><b><i> %C *use proxy for ssl (C0 don't use) </i></b></pre>
+
+<p align=justify> If there are and links to ssl URLs (URLs using HTTPS rather than the hypertext transfer protocol
+HTTP), go through the proxy server to get them.
 
 <pre><b><i>  cN number of multiple connections (*c8) </i></b></pre>
 
@@ -678,7 +685,9 @@ a remote server.
 <pre><b><i>Proxy options:
   P  proxy use (-P proxy:port or -P user:pass@proxy:port)
  %f *use proxy for ftp (f0 don't use)
+ %C *use proxy for ssl (C0 don't use)
 </i></b></pre>
+
 
 <p align=justify> If you are using a standard proxy that doesn't require
 a user ID and password, you would do something like this:

--- a/man/httrack.1
+++ b/man/httrack.1
@@ -22,6 +22,8 @@ httrack \- offline browser : copy websites to a local directory
 ] [ 
 .B \-%f, \-\-httpproxy\-ftp[=N] 
 ] [ 
+.B \-%C, \-\-httpproxy\-ssl[=N] 
+] [ 
 .B \-%b, \-\-bind 
 ] [ 
 .B \-rN, \-\-depth[=N] 
@@ -230,6 +232,8 @@ mirror ALL links located in the first level pages (mirror links) (\-\-mirrorlink
 proxy use (\-P proxy:port or \-P user:pass@proxy:port) (\-\-proxy <param>)
 .IP \-%f
 *use proxy for ftp (f0 don t use) (\-\-httpproxy\-ftp[=N])
+.IP \-%C
+*use proxy for ssl (C0 don t use) (\-\-httpproxy\-ssl[=N])
 .IP \-%b
 use this local hostname to make/send requests (\-%b hostname) (\-\-bind <param>)
 

--- a/src/htsalias.c
+++ b/src/htsalias.c
@@ -85,6 +85,7 @@ const char *hts_optalias[][4] = {
   {"proxy", "-P", "param1", "proxy name:port"},
   {"bind", "-%b", "param1", "hostname to bind"},
   {"httpproxy-ftp", "-%f", "param", ""},
+  {"httpproxy-ssl", "-%C", "param", ""},
   {"depth", "-r", "param", ""}, {"recurse-levels", "-r", "param", ""},
   {"ext-depth", "-%e", "param", ""},
   {"max-files", "-m", "param", ""},

--- a/src/htsback.c
+++ b/src/htsback.c
@@ -1955,7 +1955,7 @@ int back_add(struct_back * sback, httrackp * opt, cache_back * cache, const char
         }
       }
 #if HTS_USEOPENSSL
-      else if (strfield(back[p].url_adr, "https://")) {     // let's rock
+      else if (strfield(back[p].url_adr, "https://") && ! opt->https_proxy) {     // let's rock
         back[p].r.ssl = 1;
         // back[p].r.ssl_soc = NULL;
         back[p].r.ssl_con = NULL;

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1530,6 +1530,13 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                   com++;
                 }
                 break;          // pas de compression
+			  case 'C':
+				  opt->https_proxy = 1;
+				  if (*(com + 1) == '0') {
+					  opt->https_proxy = 0;
+					  com++;
+				  }
+				  break;
               case 'f':
                 opt->ftp_proxy = 1;
                 if (*(com + 1) == '0') {
@@ -2669,6 +2676,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               na++;
               opt->proxy.active = 1;
               // Rechercher MAIS en partant de la fin à cause de user:pass@proxy:port
+			  // trans: Search BUT starting from the end because of user:pass@proxy:port
               a = argv[na] + strlen(argv[na]) - 1;
               // a=strstr(argv[na],":");  // port
               while((a > argv[na]) && (*a != ':') && (*a != '@'))

--- a/src/htshelp.c
+++ b/src/htshelp.c
@@ -508,6 +508,7 @@ void help(const char *app, int more) {
   infomsg("");
   infomsg("Proxy options:");
   infomsg("  P  proxy use (-P proxy:port or -P user:pass@proxy:port)");
+  infomsg(" %C *use proxy for ssl (C0 don't use)");
   infomsg(" %f *use proxy for ftp (f0 don't use)");
   infomsg(" %b  use this local hostname to make/send requests (-%b hostname)");
   infomsg("");

--- a/src/htsopt.h
+++ b/src/htsopt.h
@@ -370,6 +370,7 @@ struct httrackp {
   int maxcache;                 // maximum en mémoire au niveau du cache (backing)
   //int maxcache_anticipate; // maximum de liens à anticiper (majorant)
   int ftp_proxy;                // proxy http pour ftp
+  int https_proxy;                // proxy http pour https
   String filelist;              // fichier liste URL à inclure
   String urllist;               // fichier liste de filtres à inclure
   htsfilters filters;           // contient les pointeurs pour les filtres


### PR DESCRIPTION
This enables the use of a proxy for https requests.  To do so pass the new --httpproxy-ssl (or %C) option.
Note: This sends requests to the proxy over HTTP not HTTPS, most browsers use HTTPS and the connect command.
All proxies may not work with this method, Fiddler does.
Still needs full documentation and UI options added.

This likely fixes:
-  [@UnforeseenOcean](https://github.com/UnforeseenOcean) https://github.com/xroche/httrack/issues/179
- [@NatureCoin](https://github.com/NatureCoin)  https://github.com/xroche/httrack/issues/85

This also is likely able to fix some of the slow issues over https like:

- https://github.com/xroche/httrack/issues/175
- and potentially https://github.com/xroche/httrack/issues/209

through the hack of having a proxy (ie fiddler) handle the overhead and feed everything back over http.