### PR TITLE
Update max header line lengths and increased stack size to 4MB

### DIFF
--- a/src/htscore.h
+++ b/src/htscore.h
@@ -50,7 +50,7 @@ Please visit our Website: http://www.httrack.com
 #endif
 #endif
 /* END specific definitions */
-
+#define TARGET_STACK_SIZE 4 * 1024 * 1024 //4MB, for windows we set this at compile time so if changing be sure to update the proj files win has 1MB by default linux generally at least 8MB
 /* Forward definitions */
 #ifndef HTS_DEF_FWSTRUCT_lien_url
 #define HTS_DEF_FWSTRUCT_lien_url

--- a/src/htscoremain.c
+++ b/src/htscoremain.c
@@ -1794,7 +1794,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
                     HTS_PANIC_PRINTF("Empty string given");
                     htsmain_free();
                     return -1;
-                  } else if (strlen(argv[na]) >= 256) {
+                  } else if (strlen(argv[na]) >= HTS_HEADER_LINE_MAX_SIZE) {
                     HTS_PANIC_PRINTF("Header line string too long");
                     htsmain_free();
                     return -1;
@@ -2699,7 +2699,7 @@ static int hts_main_internal(int argc, char **argv, httrackp * opt) {
               return -1;
             } else {
               na++;
-              if (strlen(argv[na]) >= 126) {
+              if (strlen(argv[na]) >= HTS_HEADER_LINE_MAX_SIZE) {
                 HTS_PANIC_PRINTF("User-agent length too long");
                 htsmain_free();
                 return -1;

--- a/src/htsglobal.h
+++ b/src/htsglobal.h
@@ -206,8 +206,11 @@ Please visit our Website: http://www.httrack.com
 /* Taille max ligne de commande (>=HTS_URLMAXSIZE*2) */
 #define HTS_CDLMAXSIZE 1024
 
+
+#define HTS_HEADER_LINE_MAX_SIZE 1024*1024
+
 /* Copyright (C) 1998-2017 Xavier Roche and other contributors */
-#define HTTRACK_AFF_AUTHORS "[XR&CO'2018]"
+#define HTTRACK_AFF_AUTHORS "[XR&CO'2022]"
 #define HTS_DEFAULT_FOOTER "<!-- Mirrored from %s%s by HTTrack Website Copier/"HTTRACK_AFF_VERSION" "HTTRACK_AFF_AUTHORS", %s -->"
 #define HTTRACK_WEB "http://www.httrack.com"
 #define HTS_UPDATE_WEBSITE "http://www.httrack.com/update.php3?Product=HTTrack&Version="HTTRACK_VERSIONID"&VersionStr="HTTRACK_VERSION"&Platform=%d&Language=%s"

--- a/src/htslib.c
+++ b/src/htslib.c
@@ -885,7 +885,13 @@ int http_sendhead(httrackp* opt, t_cookie* cookie, int mode,
 	const char* xsend, const char* adr, const char* fil,
 	const char* referer_adr, const char* referer_fil,
 	htsblk* retour) {
-	char BIGSTK buffer_head_request[8192];
+#if HTS_HEADER_LINE_MAX_SIZE*4 < TARGET_STACK_SIZE /2 //mind our stacks need to keep small to avoid an overflow but if we have a huge stack lets not exceed max line lengthx4
+	char BIGSTK buffer_head_request[HTS_HEADER_LINE_MAX_SIZE * 4];
+#else
+	char BIGSTK buffer_head_request[TARGET_STACK_SIZE / 2];
+#endif // HTS_HEADER_LINE_MAX_SIZE*4 < TARGET_STACK_SIZE
+
+	
 	buff_struct bstr = { buffer_head_request, sizeof(buffer_head_request), 0 };
 
 	//int use_11=0;     // HTTP 1.1 utilisé

--- a/src/httrack.c
+++ b/src/httrack.c
@@ -223,6 +223,25 @@ int main(int argc, char **argv) {
       return;
     }
   }
+#else
+  // https://stackoverflow.com/questions/2275550/change-stack-size-for-a-c-application-in-linux-during-compilation-with-gnu-com
+  const rlim_t kStackSize = TARGET_STACK_SIZE;
+  int result;
+
+  result = getrlimit(RLIMIT_STACK, &rl);
+  if (result == 0)
+  {
+	  if (rl.rlim_cur < kStackSize)
+	  {
+		  rl.rlim_cur = kStackSize;
+		  result = setrlimit(RLIMIT_STACK, &rl);
+		  if (result != 0)
+		  {
+			  fprintf(stderr, "setrlimit returned result = %d\n", result);
+		  }
+	  }
+  }
+
 #endif
 
   signal_handlers();

--- a/src/httrack.vcxproj
+++ b/src/httrack.vcxproj
@@ -112,6 +112,7 @@
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -133,6 +134,7 @@
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -152,6 +154,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <MapExports>true</MapExports>
       <SubSystem>Console</SubSystem>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -173,7 +176,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AssemblyDebug>true</AssemblyDebug>
-      <StackReserveSize>16777216</StackReserveSize>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/webhttrack.vcxproj
+++ b/src/webhttrack.vcxproj
@@ -114,6 +114,7 @@
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -135,6 +136,7 @@
       <AdditionalDependencies>Ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateMapFile>true</GenerateMapFile>
       <MapExports>true</MapExports>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -144,7 +146,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SupportJustMyCode>true</SupportJustMyCode>
-		<TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -155,6 +157,7 @@
       <MapExports>true</MapExports>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -164,7 +167,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <SupportJustMyCode>true</SupportJustMyCode>
-		<TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
+      <TreatSpecificWarningsAsErrors>4013;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -175,6 +178,7 @@
       <MapExports>true</MapExports>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <StackReserveSize>4194304</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Allows longer user agents and larger cookies

Fixes @XP1 @krausekai @zoness32 and @overdrivemachines issue 
https://github.com/xroche/httrack/issues/152
