### PR TITLE
Ignore URI "data:..."

### DIFF
--- a/src/htsparse.c
+++ b/src/htsparse.c
@@ -1928,7 +1928,10 @@ int htsparse(htsmoduleStruct * str, htsmoduleStructExtended * stre) {
               if (strfield(html, "(Empty Reference!)")) {
                 ok = -1;        // No
               }
-
+              // Don't parse data: URI
+              if (strncmp(html, "data:", 5) == 0) {
+                ok = -1;        // No
+              }
             }
 
             if (ok == 0) {      // tester un lien


### PR DESCRIPTION
When a file contains a URI in the form "data:...", like "data:image/gif;base64,R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==)", httrack tries to download it resulting in an error. This error may sometimes (depending on the options?) lead to end the parsing of the current file.
This PR just add a tiny check for this case.